### PR TITLE
Context

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,7 @@
       "/coverage",
       "package.json",
       "package-lock.json",
-      "reportWebVitals.ts",
-      "setupTests.ts",
-      "index.tsx"
+      "index.*"
     ],
     "transform": {
       "^.+\\.(js|jsx|ts|tsx)$": [

--- a/src/HOC/AppContext.js
+++ b/src/HOC/AppContext.js
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export const AppContext = createContext();
+export const useAppContext = () => {
+	return useContext(AppContext);
+};
+
+const AppProvider = ({ children }) => {
+	const navigate = useNavigate();
+
+	return (
+		<AppContext.Provider value={{ navigate }}>{children}</AppContext.Provider>
+	);
+};
+
+export default AppProvider;

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import AppProvider from './HOC/AppContext';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AppProvider>
+        <App />
+      </AppProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/tests/App.test.js
+++ b/tests/App.test.js
@@ -1,14 +1,16 @@
-import { render, screen } from "@testing-library/react";
-import { BrowserRouter } from "react-router-dom";
-import App from "../src/App";
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import App from '../src/App';
 
-describe("App", () => {
-  it("renders Hello heading", () => {
+describe('App', () => {
+  it('renders Hello heading', () => {
+    jest.spyOn(console, 'warn').mockImplementation();
     render(
       <BrowserRouter>
         <App />
       </BrowserRouter>
     );
-    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    console.warn.mockRestore();
   });
 });

--- a/tests/HOC/AppContext.test.js
+++ b/tests/HOC/AppContext.test.js
@@ -1,0 +1,57 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { toBeInTheDocument, toBeVisible } from '@testing-library/jest-dom';
+import { useContext } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { AppContext, useAppContext } from '../../src/HOC/AppContext';
+import AppProvider from '../../src/HOC/AppContext';
+
+beforeAll(() => {
+  jest.spyOn(console, 'warn').mockImplementation();
+});
+
+afterAll(() => {
+  console.warn.mockRestore();
+});
+
+describe('AppProvider', () => {
+  it('should render', () => {
+    render(<AppProvider>test-provider</AppProvider>, {
+      wrapper: BrowserRouter,
+    });
+  });
+
+  it('should pass navigate through to AppContext.Provider', () => {
+    const TestChild = () => {
+      const value = useAppContext(AppContext);
+      expect(value).not.toBeUndefined();
+      expect(value).not.toBeNull();
+      return <div />;
+    };
+
+    render(
+      <AppProvider>
+        <TestChild />
+      </AppProvider>,
+      {
+        wrapper: BrowserRouter,
+      }
+    );
+  });
+});
+
+describe('useAppContext', () => {
+  it('should return value passed to AppContext.Provider', () => {
+    const TestChild = () => {
+      const value = useAppContext();
+      return <div data-testid={value} />;
+    };
+
+    render(
+      <AppContext.Provider value="context-provider-test">
+        <TestChild />
+      </AppContext.Provider>
+    );
+
+    expect(screen.getByTestId(/context-provider-test/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Add a context provider to wrap the entire app. The context provider is wrapped in the browser router and wraps the App component, so the provider supplies the navigate function from react-router-dom to App through the context. This should make it easier to test that the navigate function is being called properly by anything that is wrapped in AppProvider.