### PR TITLE
Request api

### DIFF
--- a/src/API/RequestAPI.js
+++ b/src/API/RequestAPI.js
@@ -1,0 +1,11 @@
+import { request } from './request';
+
+class RequestAPI {
+
+	static getRequest = async (endpoint) => {
+		return await request({endpoint: endpoint, method: "GET"});
+	}
+
+}
+
+export default RequestAPI;

--- a/src/API/RequestAPI.js
+++ b/src/API/RequestAPI.js
@@ -22,6 +22,22 @@ class RequestAPI {
 		}
 	}
 
+	static putRequest = async (data, endpoint) => {
+		try {
+			if (data === undefined)
+				throw new Error("Put request body cannot be undefined");
+			if (data === null)
+				throw new Error("Put request body cannot be null");
+			if (data.constructor !== Object)
+				throw new Error("Put request body must be a JSON object");
+
+			return await request({endpoint: endpoint, method: "PUT", body: JSON.stringify(data)});
+		} catch (error) {
+			console.error(error);
+			return {ok: false, status: 400, body: "Client error"};
+		}
+	}
+
 }
 
 export default RequestAPI;

--- a/src/API/RequestAPI.js
+++ b/src/API/RequestAPI.js
@@ -6,36 +6,12 @@ class RequestAPI {
 		return await request({endpoint: endpoint, method: "GET"});
 	}
 
-	static postRequest = async (data, endpoint) => {
-		try {
-			if (data === undefined)
-				throw new Error("Post request body cannot be undefined");
-			if (data === null)
-				throw new Error("Post request body cannot be null");
-			if (data.constructor !== Object)
-				throw new Error("Post request body must be a JSON object");
-
-			return await request({endpoint: endpoint, method: "POST", body: JSON.stringify(data)});
-		} catch (error) {
-			console.error(error);
-			return {ok: false, status: 400, body: "Client error"};
-		}
+	static postRequest = async (endpoint, data) => {
+		return await request({endpoint: endpoint, method: "POST", body: data});
 	}
 
-	static putRequest = async (data, endpoint) => {
-		try {
-			if (data === undefined)
-				throw new Error("Put request body cannot be undefined");
-			if (data === null)
-				throw new Error("Put request body cannot be null");
-			if (data.constructor !== Object)
-				throw new Error("Put request body must be a JSON object");
-
-			return await request({endpoint: endpoint, method: "PUT", body: JSON.stringify(data)});
-		} catch (error) {
-			console.error(error);
-			return {ok: false, status: 400, body: "Client error"};
-		}
+	static putRequest = async (endpoint, data) => {
+		return await request({endpoint: endpoint, method: "PUT", body: data});
 	}
 
 	static deleteRequest = async (endpoint) => {

--- a/src/API/RequestAPI.js
+++ b/src/API/RequestAPI.js
@@ -38,6 +38,10 @@ class RequestAPI {
 		}
 	}
 
+	static deleteRequest = async (endpoint) => {
+		return await request({endpoint: endpoint, method: "DELETE"});
+	}
+
 }
 
 export default RequestAPI;

--- a/src/API/RequestAPI.js
+++ b/src/API/RequestAPI.js
@@ -10,16 +10,15 @@ import { request } from './request';
  * @Function deleteRequest
  * */
 class RequestAPI {
-
 	/**
 	 * Makes request call to the given endpoint using the GET method
 	 * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
 	 * @Optional
 	 * @Param String endpoint
-	*/
+	 */
 	static getRequest = async (endpoint) => {
-		return await request({endpoint: endpoint, method: "GET"});
-	}
+		return await request({ endpoint: endpoint, method: 'GET' });
+	};
 
 	/**
 	 * Makes request call to the given endpoint using the POST method and supplied data payload
@@ -28,10 +27,10 @@ class RequestAPI {
 	 * @Param String endpoint
 	 * @Optional
 	 * @Param String body
-	*/
+	 */
 	static postRequest = async (endpoint, data) => {
-		return await request({endpoint: endpoint, method: "POST", body: data});
-	}
+		return await request({ endpoint: endpoint, method: 'POST', body: data });
+	};
 
 	/**
 	 * Makes request call to the given endpoint using the PUT method and supplied data payload
@@ -40,21 +39,20 @@ class RequestAPI {
 	 * @Param String endpoint
 	 * @Optional
 	 * @Param String body
-	*/
+	 */
 	static putRequest = async (endpoint, data) => {
-		return await request({endpoint: endpoint, method: "PUT", body: data});
-	}
+		return await request({ endpoint: endpoint, method: 'PUT', body: data });
+	};
 
 	/**
 	 * Makes request call to the given endpoint using the DELETE method
 	 * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
 	 * @Optional
 	 * @Param String endpoint
-	*/
+	 */
 	static deleteRequest = async (endpoint) => {
-		return await request({endpoint: endpoint, method: "DELETE"});
-	}
-
+		return await request({ endpoint: endpoint, method: 'DELETE' });
+	};
 }
 
 export default RequestAPI;

--- a/src/API/RequestAPI.js
+++ b/src/API/RequestAPI.js
@@ -6,6 +6,22 @@ class RequestAPI {
 		return await request({endpoint: endpoint, method: "GET"});
 	}
 
+	static postRequest = async (data, endpoint) => {
+		try {
+			if (data === undefined)
+				throw new Error("Post request body cannot be undefined");
+			if (data === null)
+				throw new Error("Post request body cannot be null");
+			if (data.constructor !== Object)
+				throw new Error("Post request body must be a JSON object");
+
+			return await request({endpoint: endpoint, method: "POST", body: JSON.stringify(data)});
+		} catch (error) {
+			console.error(error);
+			return {ok: false, status: 400, body: "Client error"};
+		}
+	}
+
 }
 
 export default RequestAPI;

--- a/src/API/RequestAPI.js
+++ b/src/API/RequestAPI.js
@@ -1,19 +1,56 @@
 import { request } from './request';
 
+/**
+ * Interface for the request function
+ * @AllStatic
+ * @AllAsync
+ * @Function getRequest
+ * @Function postRequest
+ * @Function putRequest
+ * @Function deleteRequest
+ * */
 class RequestAPI {
 
+	/**
+	 * Makes request call to the given endpoint using the GET method
+	 * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
+	 * @Optional
+	 * @Param String endpoint
+	*/
 	static getRequest = async (endpoint) => {
 		return await request({endpoint: endpoint, method: "GET"});
 	}
 
+	/**
+	 * Makes request call to the given endpoint using the POST method and supplied data payload
+	 * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
+	 * @Optional
+	 * @Param String endpoint
+	 * @Optional
+	 * @Param String body
+	*/
 	static postRequest = async (endpoint, data) => {
 		return await request({endpoint: endpoint, method: "POST", body: data});
 	}
 
+	/**
+	 * Makes request call to the given endpoint using the PUT method and supplied data payload
+	 * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
+	 * @Optional
+	 * @Param String endpoint
+	 * @Optional
+	 * @Param String body
+	*/
 	static putRequest = async (endpoint, data) => {
 		return await request({endpoint: endpoint, method: "PUT", body: data});
 	}
 
+	/**
+	 * Makes request call to the given endpoint using the DELETE method
+	 * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
+	 * @Optional
+	 * @Param String endpoint
+	*/
 	static deleteRequest = async (endpoint) => {
 		return await request({endpoint: endpoint, method: "DELETE"});
 	}

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -5,26 +5,34 @@
  * @Optional
  * @Param {Object} args: {endpoint: String, method: String, body: String}
  * @Default fetch method is GET
-*/
+ */
 export const request = async (args) => {
-	let { endpoint, method, body } = args ?? {endpoint: null, method: "GET", body: null};
+	let { endpoint, method, body } = args ?? {
+		endpoint: null,
+		method: 'GET',
+		body: null,
+	};
 
 	endpoint = `http://localhost:8080${endpoint}`;
 
-	if (method === undefined)
-		method = "GET";
-	else if (method !== "GET" && method !== "PUT" && method !== "POST" && method !== "DELETE")
-		return {ok: false, status: 405, body: null};
+	if (method === undefined) method = 'GET';
+	else if (
+		method !== 'GET' &&
+		method !== 'PUT' &&
+		method !== 'POST' &&
+		method !== 'DELETE'
+	)
+		return { ok: false, status: 405, body: null };
 
 	try {
-		const response = await fetch(endpoint, {method: method, body: body});
+		const response = await fetch(endpoint, { method: method, body: body });
 
 		if (response === undefined || response === null)
-			throw new Error("An unexpected error occurred");
+			throw new Error('An unexpected error occurred');
 
 		return response;
 	} catch (error) {
 		console.error(error);
-		return {ok: false, status: 600, body: null};
+		return { ok: false, status: 600, body: null };
 	}
-}
+};

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -39,7 +39,7 @@ export const request = async (args) => {
 		const ret = {
 			ok: true,
 			status: response.status,
-			body: await response.text(),
+			body: await JSON.parse(await response.text()),
 		};
 
 		return ret;

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -1,8 +1,5 @@
 export const request = async (args) => {
-	if (args === undefined || args === null || args.endpoint === undefined)
-		return {ok: false, status: 400, body: null};
-
-	let { endpoint, method, body } = args;
+	let { endpoint, method, body } = args ?? {endpoint: null, method: "GET", body: null};
 
 	endpoint = `http://localhost:8080${endpoint}`;
 

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -27,12 +27,22 @@ export const request = async (args) => {
 		return { ok: false, status: 405, body: null };
 
 	try {
-		const response = await fetch(endpoint, { method: method, body: body });
+		const response = await fetch(endpoint, {
+			method: method,
+			body: body,
+			headers: { 'content-type': 'application/json' },
+		});
 
 		if (response === undefined || response === null)
 			throw new Error('An unexpected error occurred');
 
-		return response;
+		const ret = {
+			ok: true,
+			status: response.status,
+			body: await response.text(),
+		};
+
+		return ret;
 	} catch (error) {
 		console.error(error);
 		return { ok: false, status: 600, body: null };

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -1,3 +1,11 @@
+/**
+ * Makes a fetch request using http://localhost:8080 as the base URL
+ * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
+ * @Throws when fetch() returns undefined || null
+ * @Optional
+ * @Param {Object} args: {endpoint: String, method: String, body: String}
+ * @Default fetch method is GET
+*/
 export const request = async (args) => {
 	let { endpoint, method, body } = args ?? {endpoint: null, method: "GET", body: null};
 

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -1,0 +1,25 @@
+export const request = async (args) => {
+	if (args === undefined || args === null || args.endpoint === undefined)
+		return {ok: false, status: 400, body: null};
+
+	let { endpoint, method, body } = args;
+
+	endpoint = `http://localhost:8080${endpoint}`;
+
+	if (method === undefined)
+		method = "GET";
+	else if (method !== "GET" && method !== "PUT" && method !== "POST" && method !== "DELETE")
+		return {ok: false, status: 405, body: null};
+
+	try {
+		const response = await fetch(endpoint, {method: method, body: body});
+
+		if (response === undefined || response === null)
+			throw new Error("An unexpected error occurred");
+
+		return response;
+	} catch (error) {
+		console.error(error);
+		return {ok: false, status: 600, body: null};
+	}
+}

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -2,10 +2,10 @@ export const domain = 'http://localhost:8080';
 
 /**
  * Makes a fetch request using http://localhost:8080 as the base URL
- * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
- * @Throws when fetch() returns undefined || null
  * @Optional
  * @Param {Object} args: {endpoint: String, method: String, body: String}
+ * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
+ * @Throws when fetch() returns undefined || null
  * @Default fetch method is GET
  */
 export const request = async (args) => {

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -1,3 +1,5 @@
+export const domain = 'http://localhost:8080';
+
 /**
  * Makes a fetch request using http://localhost:8080 as the base URL
  * @Returns {Object} HTTP response: {ok: boolean, status: int, body: String}
@@ -13,7 +15,7 @@ export const request = async (args) => {
 		body: null,
 	};
 
-	endpoint = `http://localhost:8080${endpoint}`;
+	endpoint = `${domain}${endpoint}`;
 
 	if (method === undefined) method = 'GET';
 	else if (

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -1,5 +1,3 @@
-export const domain = 'http://localhost:8080';
-
 /**
  * Makes a fetch request using http://localhost:8080 as the base URL
  * @Optional
@@ -15,7 +13,7 @@ export const request = async (args) => {
 		body: null,
 	};
 
-	endpoint = `${domain}${endpoint}`;
+	endpoint = `http://localhost:8080${endpoint}`;
 
 	if (method === undefined) method = 'GET';
 	else if (

--- a/src/API/request.js
+++ b/src/API/request.js
@@ -24,7 +24,7 @@ export const request = async (args) => {
 		method !== 'POST' &&
 		method !== 'DELETE'
 	)
-		return { ok: false, status: 405, body: null };
+		return { ok: false, status: 405, body: { message: 'unsupported method' } };
 
 	try {
 		const response = await fetch(endpoint, {
@@ -45,6 +45,10 @@ export const request = async (args) => {
 		return ret;
 	} catch (error) {
 		console.error(error);
-		return { ok: false, status: 600, body: null };
+		return {
+			ok: false,
+			status: 600,
+			body: { message: 'unable to make request' },
+		};
 	}
 };

--- a/tests/API/RequestAPI.test.js
+++ b/tests/API/RequestAPI.test.js
@@ -1,0 +1,31 @@
+jest.mock('../../src/API/request');
+
+import * as request from '../../src/API/request';
+import RequestAPI from '../../src/API/RequestAPI';
+
+const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+const requestSpy = jest.spyOn(request, 'request');
+
+afterEach(() => {
+	jest.resetAllMocks();
+});
+
+describe('RequestAPI.getRequest', () => {
+	
+	it('should call request with correct args', async () => {
+		const endpoint = "/endpoint";
+		await RequestAPI.getRequest(endpoint);
+
+		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "GET"});
+	});
+
+	it('should return result from request call', async () => {
+		const expectedResult = "result"
+		request.request = requestSpy.mockImplementation(() => expectedResult);
+
+		const response = await RequestAPI.getRequest();
+
+		expect(response).toBe(expectedResult);
+	});
+
+});

--- a/tests/API/RequestAPI.test.js
+++ b/tests/API/RequestAPI.test.js
@@ -29,3 +29,54 @@ describe('RequestAPI.getRequest', () => {
 	});
 
 });
+
+describe('RequestAPI.postRequest', () => {
+	
+	it('should call request with correct args', async () => {
+		const endpoint = "/post";
+		const data = {test: "test-data"};
+		const dataString = JSON.stringify(data);
+		await RequestAPI.postRequest(data, endpoint);
+
+		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "POST", body: dataString});
+	});
+
+	it('should return result from good request call', async () => {
+		const expectedResult = "result"
+		request.request = requestSpy.mockImplementation(() => expectedResult);
+
+		const response = await RequestAPI.postRequest({test: "test-data"}, "/post/good/request");
+
+		expect(response).toBe(expectedResult);
+	});
+
+	describe('exceptions', () => {
+
+		afterEach(() => {
+			errorSpy.mockReset();
+		});
+
+		it('should throw when data arg is undefined', async () => {
+			const response = await RequestAPI.postRequest();
+
+			expect(errorSpy).toHaveBeenCalledWith(new Error("Post request body cannot be undefined"));
+			expect(response.status).toBe(400);
+		});
+
+		it('should throw when data arg is null', async () => {
+			const response = await RequestAPI.postRequest(null);
+
+			expect(errorSpy).toHaveBeenCalledWith(new Error("Post request body cannot be null"));
+			expect(response.status).toBe(400);
+		});
+	
+		it('should throw when data arg is not a json object', async () => {
+			const response = await RequestAPI.postRequest("string");
+
+			expect(errorSpy).toHaveBeenCalledWith(new Error("Post request body must be a JSON object"));
+			expect(response.status).toBe(400);
+		});
+
+	});
+
+});

--- a/tests/API/RequestAPI.test.js
+++ b/tests/API/RequestAPI.test.js
@@ -13,7 +13,7 @@ afterEach(() => {
 describe('RequestAPI.getRequest', () => {
 	
 	it('should call request with correct args', async () => {
-		const endpoint = "/endpoint";
+		const endpoint = "/get";
 		await RequestAPI.getRequest(endpoint);
 
 		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "GET"});
@@ -128,6 +128,26 @@ describe('RequestAPI.putRequest', () => {
 			expect(response.status).toBe(400);
 		});
 
+	});
+
+});
+
+describe('RequestAPI.deleteRequest', () => {
+
+	it('should call request with correct args', async () => {
+		const endpoint = "/delete";
+		await RequestAPI.deleteRequest(endpoint);
+
+		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "DELETE"});
+	});
+
+	it('should return result from request call', async () => {
+		const expectedResult = "result"
+		request.request = requestSpy.mockImplementation(() => expectedResult);
+
+		const response = await RequestAPI.deleteRequest();
+
+		expect(response).toBe(expectedResult);
 	});
 
 });

--- a/tests/API/RequestAPI.test.js
+++ b/tests/API/RequestAPI.test.js
@@ -80,3 +80,54 @@ describe('RequestAPI.postRequest', () => {
 	});
 
 });
+
+describe('RequestAPI.putRequest', () => {
+	
+	it('should call request with correct args', async () => {
+		const endpoint = "/put";
+		const data = {test: "test-data"};
+		const dataString = JSON.stringify(data);
+		await RequestAPI.putRequest(data, endpoint);
+
+		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "PUT", body: dataString});
+	});
+
+	it('should return result from good request call', async () => {
+		const expectedResult = "result"
+		request.request = requestSpy.mockImplementation(() => expectedResult);
+
+		const response = await RequestAPI.putRequest({test: "test-data"}, "/put/good/request");
+
+		expect(response).toBe(expectedResult);
+	});
+
+	describe('exceptions', () => {
+
+		afterEach(() => {
+			errorSpy.mockReset();
+		});
+
+		it('should throw when data arg is undefined', async () => {
+			const response = await RequestAPI.putRequest();
+
+			expect(errorSpy).toHaveBeenCalledWith(new Error("Put request body cannot be undefined"));
+			expect(response.status).toBe(400);
+		});
+
+		it('should throw when data arg is null', async () => {
+			const response = await RequestAPI.putRequest(null);
+
+			expect(errorSpy).toHaveBeenCalledWith(new Error("Put request body cannot be null"));
+			expect(response.status).toBe(400);
+		});
+	
+		it('should throw when data arg is not a json object', async () => {
+			const response = await RequestAPI.putRequest("string");
+
+			expect(errorSpy).toHaveBeenCalledWith(new Error("Put request body must be a JSON object"));
+			expect(response.status).toBe(400);
+		});
+
+	});
+
+});

--- a/tests/API/RequestAPI.test.js
+++ b/tests/API/RequestAPI.test.js
@@ -11,83 +11,93 @@ afterEach(() => {
 });
 
 describe('RequestAPI.getRequest', () => {
-	
 	it('should call request with correct args', async () => {
-		const endpoint = "/get";
+		const endpoint = '/get';
 		await RequestAPI.getRequest(endpoint);
 
-		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "GET"});
+		expect(requestSpy).toHaveBeenCalledWith({
+			endpoint: endpoint,
+			method: 'GET',
+		});
 	});
 
 	it('should return result from request call', async () => {
-		const expectedResult = "result"
+		const expectedResult = 'result';
 		request.request = requestSpy.mockImplementation(() => expectedResult);
 
 		const response = await RequestAPI.getRequest();
 
 		expect(response).toBe(expectedResult);
 	});
-
 });
 
 describe('RequestAPI.postRequest', () => {
-	
 	it('should call request with correct args', async () => {
-		const endpoint = "/post";
-		const data = {test: "test-data"};
+		const endpoint = '/post';
+		const data = { test: 'test-data' };
 		await RequestAPI.postRequest(endpoint, data);
 
-		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "POST", body: data});
+		expect(requestSpy).toHaveBeenCalledWith({
+			endpoint: endpoint,
+			method: 'POST',
+			body: data,
+		});
 	});
 
 	it('should return result from good request call', async () => {
-		const expectedResult = "result"
+		const expectedResult = 'result';
 		request.request = requestSpy.mockImplementation(() => expectedResult);
 
-		const response = await RequestAPI.postRequest("/post/good/request", {test: "test-data"});
+		const response = await RequestAPI.postRequest('/post/good/request', {
+			test: 'test-data',
+		});
 
 		expect(response).toBe(expectedResult);
 	});
-
 });
 
 describe('RequestAPI.putRequest', () => {
-	
 	it('should call request with correct args', async () => {
-		const endpoint = "/put";
-		const data = {test: "test-data"};
+		const endpoint = '/put';
+		const data = { test: 'test-data' };
 		await RequestAPI.putRequest(endpoint, data);
 
-		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "PUT", body: data});
+		expect(requestSpy).toHaveBeenCalledWith({
+			endpoint: endpoint,
+			method: 'PUT',
+			body: data,
+		});
 	});
 
 	it('should return result from good request call', async () => {
-		const expectedResult = "result"
+		const expectedResult = 'result';
 		request.request = requestSpy.mockImplementation(() => expectedResult);
 
-		const response = await RequestAPI.putRequest("/put/good/request", {test: "test-data"});
+		const response = await RequestAPI.putRequest('/put/good/request', {
+			test: 'test-data',
+		});
 
 		expect(response).toBe(expectedResult);
 	});
-
 });
 
 describe('RequestAPI.deleteRequest', () => {
-
 	it('should call request with correct args', async () => {
-		const endpoint = "/delete";
+		const endpoint = '/delete';
 		await RequestAPI.deleteRequest(endpoint);
 
-		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "DELETE"});
+		expect(requestSpy).toHaveBeenCalledWith({
+			endpoint: endpoint,
+			method: 'DELETE',
+		});
 	});
 
 	it('should return result from request call', async () => {
-		const expectedResult = "result"
+		const expectedResult = 'result';
 		request.request = requestSpy.mockImplementation(() => expectedResult);
 
 		const response = await RequestAPI.deleteRequest();
 
 		expect(response).toBe(expectedResult);
 	});
-
 });

--- a/tests/API/RequestAPI.test.js
+++ b/tests/API/RequestAPI.test.js
@@ -35,48 +35,18 @@ describe('RequestAPI.postRequest', () => {
 	it('should call request with correct args', async () => {
 		const endpoint = "/post";
 		const data = {test: "test-data"};
-		const dataString = JSON.stringify(data);
-		await RequestAPI.postRequest(data, endpoint);
+		await RequestAPI.postRequest(endpoint, data);
 
-		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "POST", body: dataString});
+		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "POST", body: data});
 	});
 
 	it('should return result from good request call', async () => {
 		const expectedResult = "result"
 		request.request = requestSpy.mockImplementation(() => expectedResult);
 
-		const response = await RequestAPI.postRequest({test: "test-data"}, "/post/good/request");
+		const response = await RequestAPI.postRequest("/post/good/request", {test: "test-data"});
 
 		expect(response).toBe(expectedResult);
-	});
-
-	describe('exceptions', () => {
-
-		afterEach(() => {
-			errorSpy.mockReset();
-		});
-
-		it('should throw when data arg is undefined', async () => {
-			const response = await RequestAPI.postRequest();
-
-			expect(errorSpy).toHaveBeenCalledWith(new Error("Post request body cannot be undefined"));
-			expect(response.status).toBe(400);
-		});
-
-		it('should throw when data arg is null', async () => {
-			const response = await RequestAPI.postRequest(null);
-
-			expect(errorSpy).toHaveBeenCalledWith(new Error("Post request body cannot be null"));
-			expect(response.status).toBe(400);
-		});
-	
-		it('should throw when data arg is not a json object', async () => {
-			const response = await RequestAPI.postRequest("string");
-
-			expect(errorSpy).toHaveBeenCalledWith(new Error("Post request body must be a JSON object"));
-			expect(response.status).toBe(400);
-		});
-
 	});
 
 });
@@ -86,48 +56,18 @@ describe('RequestAPI.putRequest', () => {
 	it('should call request with correct args', async () => {
 		const endpoint = "/put";
 		const data = {test: "test-data"};
-		const dataString = JSON.stringify(data);
-		await RequestAPI.putRequest(data, endpoint);
+		await RequestAPI.putRequest(endpoint, data);
 
-		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "PUT", body: dataString});
+		expect(requestSpy).toHaveBeenCalledWith({endpoint: endpoint, method: "PUT", body: data});
 	});
 
 	it('should return result from good request call', async () => {
 		const expectedResult = "result"
 		request.request = requestSpy.mockImplementation(() => expectedResult);
 
-		const response = await RequestAPI.putRequest({test: "test-data"}, "/put/good/request");
+		const response = await RequestAPI.putRequest("/put/good/request", {test: "test-data"});
 
 		expect(response).toBe(expectedResult);
-	});
-
-	describe('exceptions', () => {
-
-		afterEach(() => {
-			errorSpy.mockReset();
-		});
-
-		it('should throw when data arg is undefined', async () => {
-			const response = await RequestAPI.putRequest();
-
-			expect(errorSpy).toHaveBeenCalledWith(new Error("Put request body cannot be undefined"));
-			expect(response.status).toBe(400);
-		});
-
-		it('should throw when data arg is null', async () => {
-			const response = await RequestAPI.putRequest(null);
-
-			expect(errorSpy).toHaveBeenCalledWith(new Error("Put request body cannot be null"));
-			expect(response.status).toBe(400);
-		});
-	
-		it('should throw when data arg is not a json object', async () => {
-			const response = await RequestAPI.putRequest("string");
-
-			expect(errorSpy).toHaveBeenCalledWith(new Error("Put request body must be a JSON object"));
-			expect(response.status).toBe(400);
-		});
-
 	});
 
 });

--- a/tests/API/request.test.js
+++ b/tests/API/request.test.js
@@ -64,7 +64,6 @@ describe('request', () => {
 
 			const response = await request({ endpoint: '/' });
 
-			expect(errorSpy).toHaveBeenCalled();
 			expect(errorSpy).toHaveBeenCalledWith(
 				new Error('An unexpected error occurred')
 			);
@@ -78,7 +77,6 @@ describe('request', () => {
 
 			const response = await request({ endpoint: '/' });
 
-			expect(errorSpy).toHaveBeenCalled();
 			expect(errorSpy).toHaveBeenCalledWith(
 				new Error('An unexpected error occurred')
 			);

--- a/tests/API/request.test.js
+++ b/tests/API/request.test.js
@@ -3,23 +3,14 @@ import * as API from '../../src/API/request';
 const request = API.request;
 
 const isHttpResponse = (obj) => {
-	if (obj === undefined || obj == null)
-		return false;
-
-	if (obj.ok === undefined)
-		return false;
-
-	if (obj.status === undefined || obj.status === null)
-		return false;
-
-	if (obj.body === undefined)
-		return false;
-
+	if (obj === undefined || obj == null) return false;
+	if (obj.ok === undefined) return false;
+	if (obj.status === undefined || obj.status === null) return false;
+	if (obj.body === undefined) return false;
 	return true;
-}
+};
 
 describe('request', () => {
-
 	const unmockedFetch = global.fetch;
 
 	afterEach(() => {
@@ -27,29 +18,35 @@ describe('request', () => {
 	});
 
 	it('should return http response', async () => {
-		global.fetch = jest.fn(async () => Promise.resolve({ok: true, status: 200, body: null}));
+		global.fetch = jest.fn(async () =>
+			Promise.resolve({ ok: true, status: 200, body: null })
+		);
 		const response = await request();
 
 		expect(isHttpResponse(response)).toBe(true);
 	});
 
 	it('should return 405 for unsupported HTTP methods', async () => {
-		const response = await request({endpoint: "/", method: "unsupported method"});
+		const response = await request({
+			endpoint: '/',
+			method: 'unsupported method',
+		});
 		expect(response.status).toBe(405);
 	});
 
 	it('should default to GET method', async () => {
-		const mockFetch = jest.fn(async () => Promise.resolve({ok: true, status: 200}));
+		const mockFetch = jest.fn(async () =>
+			Promise.resolve({ ok: true, status: 200 })
+		);
 		global.fetch = mockFetch;
 
-		await request({endpoint: "/"});
+		await request({ endpoint: '/' });
 
 		expect(mockFetch.mock.calls).toHaveLength(1);
-		expect(mockFetch.mock.calls[0][1].method).toBe("GET");
+		expect(mockFetch.mock.calls[0][1].method).toBe('GET');
 	});
 
 	describe('exceptions', () => {
-
 		const unmockedError = console.error;
 		const errorSpy = jest.spyOn(console, 'error').mockImplementation();
 
@@ -64,10 +61,12 @@ describe('request', () => {
 		it('should throw error on undefined response', async () => {
 			global.fetch = jest.fn(async () => Promise.resolve());
 
-			const response = await request({endpoint: "/"});
+			const response = await request({ endpoint: '/' });
 
 			expect(errorSpy).toHaveBeenCalled();
-			expect(errorSpy).toHaveBeenCalledWith(new Error("An unexpected error occurred"));
+			expect(errorSpy).toHaveBeenCalledWith(
+				new Error('An unexpected error occurred')
+			);
 
 			expect(isHttpResponse(response)).toBe(true);
 			expect(response.status).toBe(600);
@@ -76,16 +75,15 @@ describe('request', () => {
 		it('should throw error on null response', async () => {
 			global.fetch = jest.fn(async () => Promise.resolve(null));
 
-			const response = await request({endpoint: "/"});
+			const response = await request({ endpoint: '/' });
 
 			expect(errorSpy).toHaveBeenCalled();
-			expect(errorSpy).toHaveBeenCalledWith(new Error("An unexpected error occurred"));
-
+			expect(errorSpy).toHaveBeenCalledWith(
+				new Error('An unexpected error occurred')
+			);
 
 			expect(isHttpResponse(response)).toBe(true);
 			expect(response.status).toBe(600);
 		});
-
 	});
-
 });

--- a/tests/API/request.test.js
+++ b/tests/API/request.test.js
@@ -1,0 +1,107 @@
+import * as API from '../../src/API/request';
+
+const request = API.request;
+
+const isHttpResponse = (obj) => {
+	if (obj === undefined || obj == null)
+		return false;
+
+	if (obj.ok === undefined)
+		return false;
+
+	if (obj.status === undefined || obj.status === null)
+		return false;
+
+	if (obj.body === undefined)
+		return false;
+
+	return true;
+}
+
+describe('request', () => {
+
+	const unmockedFetch = global.fetch;
+
+	afterEach(() => {
+		global.fetch = unmockedFetch;
+	});
+
+	it('should return http response on good request', async () => {
+		global.fetch = jest.fn(async () => Promise.resolve({ok: true, status: 200, body: null}));
+		const response = await request({endpoint: "/", method: "GET"});
+
+		expect(isHttpResponse(response)).toBe(true);
+	});
+
+	it('should return http response on bad request', async () => {
+		const response = await request();
+
+		expect(isHttpResponse(response)).toBe(true);
+	});
+
+	it('should return 400 response status if args is undefined or null', async () => {
+		let response;
+
+		response = await request();
+		expect(response.status).toBe(400);
+
+		response = await request(null);
+		expect(response.status).toBe(400);
+	});
+
+	it('should return 405 for unsupported HTTP methods', async () => {
+		const response = await request({endpoint: "/", method: "unsupported method"});
+		expect(response.status).toBe(405);
+	});
+
+	it('should default to GET method', async () => {
+		const mockFetch = jest.fn(async () => Promise.resolve({ok: true, status: 200}));
+		global.fetch = mockFetch;
+
+		await request({endpoint: "/"});
+
+		expect(mockFetch.mock.calls).toHaveLength(1);
+		expect(mockFetch.mock.calls[0][1].method).toBe("GET");
+	});
+
+	describe('exceptions', () => {
+
+		const unmockedError = console.error;
+		const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+		afterAll(() => {
+			console.error = unmockedError;
+		});
+
+		afterEach(() => {
+			errorSpy.mockReset();
+		});
+
+		it('should throw error on undefined response', async () => {
+			global.fetch = jest.fn(async () => Promise.resolve());
+
+			const response = await request({endpoint: "/"});
+
+			expect(errorSpy).toHaveBeenCalled();
+			expect(errorSpy).toHaveBeenCalledWith(new Error("An unexpected error occurred"));
+
+			expect(isHttpResponse(response)).toBe(true);
+			expect(response.status).toBe(600);
+		});
+
+		it('should throw error on null response', async () => {
+			global.fetch = jest.fn(async () => Promise.resolve(null));
+
+			const response = await request({endpoint: "/"});
+
+			expect(errorSpy).toHaveBeenCalled();
+			expect(errorSpy).toHaveBeenCalledWith(new Error("An unexpected error occurred"));
+
+
+			expect(isHttpResponse(response)).toBe(true);
+			expect(response.status).toBe(600);
+		});
+
+	});
+
+});

--- a/tests/API/request.test.js
+++ b/tests/API/request.test.js
@@ -42,8 +42,9 @@ describe('request', () => {
 
 		await request({ endpoint: '/' });
 
-		expect(mockFetch).toHaveBeenCalledWith(`${API.domain}/`, {
+		expect(mockFetch).toHaveBeenCalledWith(`http://localhost:8080/`, {
 			method: 'GET',
+			headers: { 'content-type': 'application/json' },
 		});
 	});
 

--- a/tests/API/request.test.js
+++ b/tests/API/request.test.js
@@ -42,8 +42,9 @@ describe('request', () => {
 
 		await request({ endpoint: '/' });
 
-		expect(mockFetch.mock.calls).toHaveLength(1);
-		expect(mockFetch.mock.calls[0][1].method).toBe('GET');
+		expect(mockFetch).toHaveBeenCalledWith(`${API.domain}/`, {
+			method: 'GET',
+		});
 	});
 
 	describe('exceptions', () => {

--- a/tests/API/request.test.js
+++ b/tests/API/request.test.js
@@ -26,27 +26,11 @@ describe('request', () => {
 		global.fetch = unmockedFetch;
 	});
 
-	it('should return http response on good request', async () => {
+	it('should return http response', async () => {
 		global.fetch = jest.fn(async () => Promise.resolve({ok: true, status: 200, body: null}));
-		const response = await request({endpoint: "/", method: "GET"});
-
-		expect(isHttpResponse(response)).toBe(true);
-	});
-
-	it('should return http response on bad request', async () => {
 		const response = await request();
 
 		expect(isHttpResponse(response)).toBe(true);
-	});
-
-	it('should return 400 response status if args is undefined or null', async () => {
-		let response;
-
-		response = await request();
-		expect(response.status).toBe(400);
-
-		response = await request(null);
-		expect(response.status).toBe(400);
 	});
 
 	it('should return 405 for unsupported HTTP methods', async () => {


### PR DESCRIPTION
Add a generic method for making fetch requests to the server, handling argument validation, using a constant base domain to which the passed endpoint is appended, and defaulting to a GET request. Add an interface to the request method to abstract it out to 4 methods, getRequest, postRequest, putRequest, and deleteRequest.