### PR TITLE
add getAllActivePrescriptions function to default export object

### DIFF
--- a/src/API/PrescriptionAPI.js
+++ b/src/API/PrescriptionAPI.js
@@ -83,5 +83,10 @@ export const markPickedUp = async (prescription) => {
 	}
 };
 
-const PrescriptionAPI = { getAllPrescriptions, fillPrescription, markPickedUp };
+const PrescriptionAPI = {
+	getAllPrescriptions,
+	getAllActivePrescriptions,
+	fillPrescription,
+	markPickedUp,
+};
 export default PrescriptionAPI;


### PR DESCRIPTION
Forgot to add getAllActivePrescriptions to the default export object.